### PR TITLE
alabado chatGPT

### DIFF
--- a/src/components/dashboard/BasicCard.js
+++ b/src/components/dashboard/BasicCard.js
@@ -4,7 +4,7 @@ import CardActions from "@mui/material/CardActions";
 import CardContent from "@mui/material/CardContent";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
-import { useDispatch } from "react-redux";
+//import { useDispatch } from "react-redux";
 //import { deleteTicket } from "../../redux/actions/actionIndex";
 
 export default function BasicCard(props) {

--- a/src/components/dashboard/Clients.js
+++ b/src/components/dashboard/Clients.js
@@ -24,6 +24,7 @@ import {
   deleteTicket,
 } from "../../redux/actions/actionIndex";
 
+
 const style = {
   position: "absolute",
   top: "50%",
@@ -70,16 +71,23 @@ export default function Clients() {
     sheet: "Users",
   });
 
-  function addTickets(allTickets, allUsers) {
-    for (let i = 0; i < allUsers.length; i++) {
-      allUsers[i]["tickets"] = [];
-      allTickets.map((t) => {
-        if (allUsers[i].id === t.userId) {
-          allUsers[i]["tickets"].push(t);
-        }
-      });
-    }
-    return allUsers;
+  function addTickets(tickets, users) {
+    const groupedTickets = tickets.reduce((acc, ticket) => {
+      const userId = ticket.userId;
+      if (!acc[userId]) {
+        acc[userId] = [];
+      }
+      acc[userId].push(ticket);
+      return acc;
+    }, {});
+
+    return users.map((user) => {
+      const userTickets = groupedTickets[user.id] || [];
+      return {
+        ...user,
+        tickets: userTickets,
+      };
+    });
   }
 
   useEffect(() => {
@@ -141,7 +149,7 @@ export default function Clients() {
         </TableBody>
       </Table>
       <TablePagination
-        rowsPerPageOptions={[10, 25, 50, 100, users.length]}
+        rowsPerPageOptions={[10, 25, 50, 100]}
         component="div"
         count={users.length}
         rowsPerPage={rpg}

--- a/src/components/dashboard/TotalByStore.jsx
+++ b/src/components/dashboard/TotalByStore.jsx
@@ -18,12 +18,12 @@ const TotalByStore = () => {
     !stores.length && dispatch(getStoresDB());
   }, [stores, dispatch, tickets.length]);
 
-  const list = stores.map((store) => {
+  const list = stores.map((store, idx) => {
     return (
-      <>
-        <div className={style.horizontal}>
+      <li key={idx}>
+        <div className={style.horizontal} >
           <div className={style.storename}>{store.name}:</div>
-          <div className={style.storeslider}>
+          <div className={style.storeslider} >
             <Slider
               color="primary"
               valueLabelDisplay="on"
@@ -38,7 +38,7 @@ const TotalByStore = () => {
             />
           </div>
         </div>
-      </>
+      </li>
     );
   });
 

--- a/src/components/dashboard/TotalByStore.module.css
+++ b/src/components/dashboard/TotalByStore.module.css
@@ -12,6 +12,10 @@
   color: #e95725;
 }
 
+li {
+  list-style: none;
+}
+
 .storeslider {
   width: 85%;
 }


### PR DESCRIPTION
The addTickets function you provided loops over an array of users and maps over an array of tickets to add the tickets that belong to each user to their respective tickets array.

One reason why this function may be slow is that it has a time complexity of O(n^2), where n is the length of the users array. This is because for each user, the function loops over all the tickets to find the ones that belong to that user.

To improve the performance of this function, you could use a more efficient algorithm that has a lower time complexity. One approach is to first group the tickets by user ID into an object, and then loop over the users array and add the tickets for each user from the grouped object. Here's an example implementation:

       ---------------------------------------------------------------------------------------------------------------------

In this implementation, we first use the reduce method to group the tickets by user ID into an object called groupedTickets. The reduce method accumulates the tickets into an object where each property is a user ID and the value is an array of tickets for that user.

Then, we loop over the users array using the map method and add the corresponding tickets array to each user object by accessing it from the groupedTickets object using the user's ID as the key. If the user doesn't have any tickets, we return an empty array. Finally, we use the spread operator to merge the original user object with the new tickets property.

This implementation has a time complexity of O(n), where n is the length of the users array, which is more efficient than the previous implementation.
